### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ wsgiref>=0.1.2
 numpy>=1.8.0
 matplotlib>=1.3.1
 xlwt>=0.7.5
+pathlib>=1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ numpy>=1.8.0
 matplotlib>=1.3.1
 xlwt>=0.7.5
 pathlib>=1.0.1
+https://pyodbc.googlecode.com/files/pyodbc-3.0.7.zip


### PR DESCRIPTION
Currently, there are two dependencies not listed in `requirements.txt` that are needed to get `web.py` up and running: pathlib and pyodbc.  This pull request adds their entries to `requirements.txt`.  So to start `web.py` on a fresh install all you need to do is:
```sh
$ pip install -r requirements.txt
# Pip output
...
$ cd omf
$ python web.py
 * Running on http://127.0.0.1:5000/ (Press CTRL+C to quit)
 * Restarting with stat
# Success!
```
The entry for pyodbc looks different because its pip package is broken or not set up correctly or something.  `pip freeze` will spit out an entry for pyodbc that looks like `pyodbc==3.0.7`, but if you use that in `requirements.txt`, `pip install -r requirements.txt` will fail.