### PR TITLE
Include max random seed in vbatDispatch, derUtilityCost, and derConsumer models

### DIFF
--- a/omf/models/derConsumer.html
+++ b/omf/models/derConsumer.html
@@ -127,19 +127,19 @@
 			</div>
 			<div class="shortInput">
 				<label class="tooltip">Random Seed - BESS & GEN<span class="classic">A deterministic random seed number for the HiGHS optimizer used for the BESS and GEN technologies. Must be a positive integer between 0 and 2147483647. Please see the documentation at the help link for more information.</span></label>
-				<input type="text" id="random_seed_HiGHS_REopt" name="random_seed_HiGHS_REopt" value="{{allInputDataDict.random_seed_HiGHS_REopt}}" pattern="^\d+\.?\d*?$" required="required">
+				<input type="number" id="random_seed_HiGHS_REopt" name="random_seed_HiGHS_REopt" value="{{allInputDataDict.random_seed_HiGHS_REopt}}" pattern="^\d+\.?\d*?$" min="0" max="2147483647" required="required" >
 			</div>
 			<div class="shortInput">
 				<label class="tooltip">Random Seed - AC<span class="classic">A deterministic random seed number for the PuLP optimizer used for the water heater technology. Must be a positive integer between 0 and 2147483647. Please see the documentation at the help link for more information.</span></label>
-				<input type="text" id="random_seed_PuLP_ac" name="random_seed_PuLP_ac" value="{{allInputDataDict.random_seed_PuLP_ac}}" pattern="^\d+\.?\d*?$" required="required">
+				<input type="number" id="random_seed_PuLP_ac" name="random_seed_PuLP_ac" value="{{allInputDataDict.random_seed_PuLP_ac}}" pattern="^\d+\.?\d*?$" min="0" max="2147483647" required="required">
 			</div>
 			<div class="shortInput">
 				<label class="tooltip">Random Seed - HP<span class="classic">A deterministic random seed number for the PuLP optimizer used for the heat pump technology. Must be a positive integer between 0 and 2147483647. Please see the documentation at the help link for more information.</span></label>
-				<input type="text" id="random_seed_PuLP_hp" name="random_seed_PuLP_hp" value="{{allInputDataDict.random_seed_PuLP_hp}}" pattern="^\d+\.?\d*?$" required="required">
+				<input type="number" id="random_seed_PuLP_hp" name="random_seed_PuLP_hp" value="{{allInputDataDict.random_seed_PuLP_hp}}" pattern="^\d+\.?\d*?$" min="0" max="2147483647" required="required">
 			</div>
 			<div class="shortInput">
 				<label class="tooltip">Random Seed - WH<span class="classic">A deterministic random seed number for the PuLP optimizer used for the water heater technology. Must be a positive integer between 0 and 2147483647. Please see the documentation at the help link for more information.</span></label>
-				<input type="text" id="random_seed_PuLP_wh" name="random_seed_PuLP_wh" value="{{allInputDataDict.random_seed_PuLP_wh}}" pattern="^\d+\.?\d*?$" required="required">
+				<input type="number" id="random_seed_PuLP_wh" name="random_seed_PuLP_wh" value="{{allInputDataDict.random_seed_PuLP_wh}}" pattern="^\d+\.?\d*?$" min="0" max="2147483647" required="required">
 			</div>
 			<div class="shortInput">
 				<label class="tooltip">Random Numbers for Water Heater (.csv file)<span class="classic"> A .csv file containing the random numbers to determine the water heater's water draw in gallons per minute. If the 'Use the user-provided random numbers?' input is set to 'Yes', the model will use the provided file. If 'No', the model will generate and save the water heater random numbers to a .csv file in the output files. Please see the documentation at the help link for the required format and example file.</span></label>

--- a/omf/models/derConsumer.py
+++ b/omf/models/derConsumer.py
@@ -313,7 +313,7 @@ def work(modelDir, inputDict):
 		try:
 			BESS = reoptResults['ElectricStorage']['storage_to_load_series_kw']
 		except KeyError:
-			raise Exception(f'No BESS found in REopt. An error may have occurred, see REopts warning list: {reoptErrorMsgs}.')
+			raise Exception(f'No BESS found in REopt results. An error may have occurred, see REopts warning list: {reoptErrorMsgs}.')
 		
 		grid_charging_BESS = reoptResults['ElectricUtility']['electric_to_storage_series_kw']
 		outData['chargeLevelBattery'] = list(np.array(reoptResults['ElectricStorage']['soc_series_fraction']) * 100.)
@@ -323,7 +323,10 @@ def work(modelDir, inputDict):
 		outData['chargeLevelBattery'] = list(np.zeros_like(demand))
 
 	if GENcheck == 'enabled':
-		generator = np.array(reoptResults['Generator']['electric_to_load_series_kw'])
+		try:
+			generator = np.array(reoptResults['Generator']['electric_to_load_series_kw'])
+		except KeyError:
+			raise Exception(f'No fossil fuel generator found in REopt results. An error may have occurred, see REopts warning list: {reoptErrorMsgs}.')
 	else:
 		generator = np.zeros_like(demand)
 

--- a/omf/models/derUtilityCost.html
+++ b/omf/models/derUtilityCost.html
@@ -130,19 +130,19 @@
 			</div>
 			<div class="shortInput">
 				<label class="tooltip">Random Seed - BESS & GEN<span class="classic">A deterministic random seed number for the HiGHS optimizer used for the BESS and GEN technologies. Must be a positive integer between 0 and 2147483647. Please see the documentation at the help link for more information.</span></label>
-				<input type="text" id="random_seed_HiGHS_REopt" name="random_seed_HiGHS_REopt" value="{{allInputDataDict.random_seed_HiGHS_REopt}}" pattern="^\d+\.?\d*?$" required="required">
+				<input type="number" id="random_seed_HiGHS_REopt" name="random_seed_HiGHS_REopt" value="{{allInputDataDict.random_seed_HiGHS_REopt}}" pattern="^\d+\.?\d*?$" min="0" max="2147483647" required="required" >
 			</div>
 			<div class="shortInput">
 				<label class="tooltip">Random Seed - AC<span class="classic">A deterministic random seed number for the PuLP optimizer used for the water heater technology. Must be a positive integer between 0 and 2147483647. Please see the documentation at the help link for more information.</span></label>
-				<input type="text" id="random_seed_PuLP_ac" name="random_seed_PuLP_ac" value="{{allInputDataDict.random_seed_PuLP_ac}}" pattern="^\d+\.?\d*?$" required="required">
+				<input type="number" id="random_seed_PuLP_ac" name="random_seed_PuLP_ac" value="{{allInputDataDict.random_seed_PuLP_ac}}" pattern="^\d+\.?\d*?$" min="0" max="2147483647" required="required">
 			</div>
 			<div class="shortInput">
 				<label class="tooltip">Random Seed - HP<span class="classic">A deterministic random seed number for the PuLP optimizer used for the heat pump technology. Must be a positive integer between 0 and 2147483647. Please see the documentation at the help link for more information.</span></label>
-				<input type="text" id="random_seed_PuLP_hp" name="random_seed_PuLP_hp" value="{{allInputDataDict.random_seed_PuLP_hp}}" pattern="^\d+\.?\d*?$" required="required">
+				<input type="number" id="random_seed_PuLP_hp" name="random_seed_PuLP_hp" value="{{allInputDataDict.random_seed_PuLP_hp}}" pattern="^\d+\.?\d*?$" min="0" max="2147483647" required="required">
 			</div>
 			<div class="shortInput">
 				<label class="tooltip">Random Seed - WH<span class="classic">A deterministic random seed number for the PuLP optimizer used for the water heater technology. Must be a positive integer between 0 and 2147483647. Please see the documentation at the help link for more information.</span></label>
-				<input type="text" id="random_seed_PuLP_wh" name="random_seed_PuLP_wh" value="{{allInputDataDict.random_seed_PuLP_wh}}" pattern="^\d+\.?\d*?$" required="required">
+				<input type="number" id="random_seed_PuLP_wh" name="random_seed_PuLP_wh" value="{{allInputDataDict.random_seed_PuLP_wh}}" pattern="^\d+\.?\d*?$" min="0" max="2147483647" required="required">
 			</div>
 			<div class="shortInput">
 				<label class="tooltip">Random Numbers for Water Heater (.csv file)<span class="classic"> A .csv file containing the random numbers to determine the water heater's water draw in gallons per minute. If the 'Use the user-provided random numbers?' input is set to 'Yes', the model will use the provided file. If 'No', the model will generate and save the water heater random numbers to a .csv file in the output files. Please see the documentation at the help link for the required format and example file.</span></label>

--- a/omf/models/derUtilityCost.py
+++ b/omf/models/derUtilityCost.py
@@ -474,7 +474,10 @@ def work(modelDir, inputDict):
 		outData['chargeLevelBattery'] = list(np.zeros_like(demand))
 
 	if GENcheck == 'enabled':
-		generator = np.array(reoptResults['Generator']['electric_to_load_series_kw'])
+		try:
+			generator = np.array(reoptResults['Generator']['electric_to_load_series_kw'])
+		except KeyError:
+			raise Exception(f'No fossil fuel generator found in REopt results. An error may have occurred, see REopts warning list: {reoptErrorMsgs}.')
 	else:
 		generator = np.zeros_like(demand)
 

--- a/omf/models/vbatDispatch.html
+++ b/omf/models/vbatDispatch.html
@@ -162,8 +162,8 @@
 				</div>
 			</div>
 			<div class="shortInput">
-				<label class="tooltip">PuLP Random Seed<span class="classic">A deterministic random seed number for the PuLP optimizer. Must be a positive integer between 0 and 10000000000. Please see the documentation at the help link for more information.</span></label>
-				<input type="text" id="random_seed_PuLP" name="random_seed_PuLP" value="{{allInputDataDict.random_seed_PuLP}}" pattern="^\d+\.?\d*?$" required="required">
+				<label class="tooltip">PuLP Random Seed<span class="classic">A deterministic random seed number for the PuLP optimizer. Must be a positive integer between 0 and 2147483647. Please see the documentation at the help link for more information.</span></label>
+				<input type="number" id="random_seed_PuLP" name="random_seed_PuLP" value="{{allInputDataDict.random_seed_PuLP}}" pattern="^\d+\.?\d*?$" min="0" max="2147483647" required="required">
 			</div>
 			<div class="shortInput">
 				<label class="tooltip">Use the user-provided random numbers?<span class="classic">If 'Yes' model will use all user-provided random numbers including the Random Numbers for Water Heater (.csv) file. If 'No' the model will generate all numbers needed and save them in the model outputs. Please see the documentation at the help link for more information.</span></label>

--- a/omf/models/vbatDispatch.py
+++ b/omf/models/vbatDispatch.py
@@ -65,7 +65,7 @@ def pulpFunc(inputDict, demand, P_lower, P_upper, E_UL, monthHours):
 		PuLP_random_seed = inputDict['random_seed_PuLP']
 	else: 
 		## Generate the random seed value
-		PuLP_random_seed = str(np.random.randint(0,10000000000))
+		PuLP_random_seed = str(np.random.randint(0,2147483647))
 
 	cbc_solver = pulp.PULP_CBC_CMD(keepFiles=False,
 				msg=True,
@@ -257,7 +257,7 @@ def new(modelDir):
 		'monthlyDemandChargesFileName': 'utility_monthly_demand_charges.csv',
 		'monthlyDemandCharges': monthly_demand_charges,
 		'set_random_numbers': 'No',
-		'random_seed_PuLP': '10000000000',
+		'random_seed_PuLP': '2147483647',
 		'randomNumbersFileName': 'water_heater_random_numbers.csv',
 		'randomNumbers': random_numbers,
 	}


### PR DESCRIPTION
## vbatDispatch
- Max random seed value is added. vbatDispatch uses the CBC MILP solver and the [random seed max limit is 2147483647](https://github.com/coin-or/pulp/issues/545#issuecomment-1355737609).

## derUtilityCost & derConsumer
- Max random seed value is added. The REopt model used by derUtilityCost and derConsumer makes use of the HiGHS solver, which also has the same max [random seed limit of 2147483647](https://ergo-code.github.io/HiGHS/dev/options/definitions/#option-random-seed) as the CBC solver used in vbatDispatch.
- A warning message is added to both models in the event that no fossil fuel generator is found in the REopt results, even when the generator settings are enabled by the user. 