### PR TITLE
Fixes for model sharing visual bugs and bugs regarding model existance checks for new models

### DIFF
--- a/omf/models/__neoMetaModel__.py
+++ b/omf/models/__neoMetaModel__.py
@@ -176,8 +176,10 @@ def renderTemplate(modelDir, absolutePaths=False, datastoreNames={}):
 		<button id="deleteButton" type="button" onclick="deleteModel()">Delete</button>
 		<button id="runButton" type="submit">Run Model</button>
 		{% endif %}
-		{% if modelStatus == "finished" %}
+		{% if modelStatus == "finished" and (loggedInUser == modelOwner or loggedInUser == 'admin') %}
 		<button id="shareButton" type="button" onclick="shareModel()">Share</button>
+		{% endif %}
+		{% if modelStatus == "finished" %}
 		<button id="duplicateButton" type="button" onclick="duplicateModel()">Duplicate</button>
 		{% endif %}
 		{% if modelStatus == "running" and (loggedInUser == modelOwner or loggedInUser == 'admin') %}

--- a/omf/static/geoJsonMap/v3/main.js
+++ b/omf/static/geoJsonMap/v3/main.js
@@ -44,7 +44,12 @@ function main() {
     }
     // - Save before rendering the interface to remove any previous error files, but only in "online mode"
     if (gIsOnline) {
-        document.getElementById('saveDiv').click();
+        const saveDiv = document.getElementById('saveDiv');
+        if (saveDiv) {
+            saveDiv.click();
+        } else {
+            hideModalInsert();
+        }
     }
 }
 

--- a/omf/static/omf.js
+++ b/omf/static/omf.js
@@ -364,6 +364,8 @@ function duplicateModel() {
 			} else {
 				post_to_url("/duplicateModel/" + allInputData.user + "/" + allInputData.modelName+"/", {"newName":newName})
 			}
+		}).fail(function(jqXHR, textStatus, errorThrown) {
+			alert("AJAX request failed to get a successful response from the server.");
 		})
 	}
 }

--- a/omf/web.py
+++ b/omf/web.py
@@ -2489,10 +2489,25 @@ def downloadModelData(owner, modelName, fullPath):
 @app.route("/uniqObjName/<objtype>/<owner>/<modelName>")
 @app.route("/uniqObjName/<objtype>/<owner>/<modelName>/<name>")
 @flask_login.login_required
-@read_permission_function # This route needs read permissions because duplicate model uses it
 def uniqObjName(objtype, owner, modelName=None, name=None):
 	"""Checks if a given object type/owner/name is unique. More like checks if a file exists on the server"""
 	print("Entered uniqobjname", owner, modelName, name)
+	# Inline authorization (replaces @read_permission_function).
+	# Model checks only need ownership — the model may not exist yet.
+	# Feeder/Network/circuitFile checks need the parent model to exist
+	# and the user to have read access.
+	if objtype == 'Model':
+		if owner != User.cu() and User.cu() != 'admin':
+			return redirect('/')
+	else:
+		if owner == 'public':
+			pass  # Any authenticated user can check public resources
+		else:
+			model_metadata_path = path_manager.join('data', 'Model', owner, modelName, 'allInputData.json')
+			if not os.path.isfile(model_metadata_path):
+				return redirect('/')
+			if owner != User.cu() and not _is_authorized_model_viewer(owner, modelName) and User.cu() != 'admin':
+				return redirect('/')
 	# For Model type, the 3-segment route puts the name-to-check in modelName.
 	if objtype == 'Model':
 		name = modelName


### PR DESCRIPTION
omf.js - add AJAX .fail() handler to duplicateModel() to be consistent with createModelName()
web.py - added inline permission authorization check to /uniqObjName and removed @read_permission_function decorator because /uniqObjName is used in situations where a model does not exist yet but @read_permission_function decorator assumes a model exists and redirects if it does not. Existing functionality with /uniqObjName and new models has been working by accident only because the redirect by @read_permission_function has been returning HTML and data.exists was undefined because HTML doesn't have that JavaScript property and data.exists == false hit the else-branch in the JavaScript which would call newModel from omf.js. The fix now correctly checks if a name being requested by a new model exists on the server
__neoMetaModel__.py - fixed old bug where the "share" button would appear for model viewers that don't own a model that has been shared with them"
main.js - fixed a bug in which a viewer of a shared model would see a "loading map..." modal hang when they opened the shared model circuit in the circuit editor. This modal could be removed by clicking but now it is removed automatically